### PR TITLE
Store the ID with the record.

### DIFF
--- a/localstorage_adapter.js
+++ b/localstorage_adapter.js
@@ -93,7 +93,7 @@ DS.LSAdapter = DS.Adapter.extend(Ember.Evented, {
     this._async(function() {
       records.forEach(function(record) {
         var id = record.get('id');
-        namespace.records[id] = record.toData();
+        namespace.records[id] = record.toData({includeId:true});
       }, this);
       this._didSaveRecords(store, type, records);
     });
@@ -157,7 +157,7 @@ DS.LSAdapter = DS.Adapter.extend(Ember.Evented, {
   _addRecordToNamespace: function(namespace, record) {
     var id = namespace.last_id = namespace.last_id + 1;
     record.set('id', id);
-    namespace.records[id] = record.toData();
+    namespace.records[id] = record.toData({includeId:true});
   },
 
   _async: function(callback) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -173,6 +173,8 @@ test('findAll', function() {
 test('createRecords', function() {
   createAndSaveNewList();
   equal(list.get('id'), 4, 'id is incremented for new records');
+  storedList = getStoredLists()[list.get('id')]
+  equal(storedList.id, 4, 'id is stored with record');
 });
 
 test('updateRecords', function() {
@@ -182,6 +184,7 @@ test('updateRecords', function() {
   var storedList = getStoredLists()[list.get('id')];
   equal(list.get('name'), 'updated');
   equal(storedList.name, list.get('name'));
+  equal(storedList.id, list.get('id'));
 });
 
 test('deleteRecords', function() {


### PR DESCRIPTION
Use includeId:true when calling toData on the object.

Without this change objects were being stored with their ids as a key but not in the JSON itself. `preprocessData` would return ["undefined", "undefined"] and it would only load one object.

The alternative option is to record the object ids when pulling them from localstorage and pass them as  a third argument to loadMany etc, but this seems cleaner to me.
