### PR TITLE
Add component.json for Bower

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,15 @@
+{
+  "name": "ember-localstorage-adapter",
+  "author": "Ryan Florence",
+  "main": "localstorage_adapter.js",
+  "version": "0.0.0",
+  "dependencies": {
+    "ember": "~1.0.0-rc.1",
+    "ember-data": "latest"
+  },
+  "ignore": [
+    "vendor/",
+    "script/",
+    "test/"
+  ]
+}


### PR DESCRIPTION
`ember-localstorage-adapter` is already listed as bower component, but isn't tagged yet and includes all the vendor files. By including the component manifest, running `bower install ember-localstorage-adapter` would just install the files from the main directory.

If you want to include this, it would be great if you could tag the repository so one can pin the version to install.
