### PR TITLE
Bug in find. A find now is an 'AND' on each property passed to find

### DIFF
--- a/localstorage_adapter.js
+++ b/localstorage_adapter.js
@@ -87,20 +87,30 @@ DS.LSAdapter = DS.Adapter.extend(Ember.Evented, {
     var results = [];
     var id, record, property, test, push;
     for (id in records) {
+      //console.log("testing order " + id);
       record = records[id];
+
+      push = true;
+
       for (property in query) {
         test = query[property];
-        push = false;
         if (Object.prototype.toString.call(test) == '[object RegExp]') {
-          push = test.test(record[property]);
+          thisTestPass = test.test(record[property]);
         } else {
-          push = record[property] === test;
+          //console.log("Prop: " + property + " Test: " + test + " EQ: " + (record[property] === test));
+          thisTestPass = record[property] === test;
+        }
+
+        if(!thisTestPass) {
+          push = false;
         }
       }
+
       if (push) {
         results.push(record);
       }
     }
+    //console.log(results[0]);
     return results;
   },
 


### PR DESCRIPTION
Doing a find is now and 'and' for each property passed to the find.

Before, it would return a record if 'ANY' of the properties matched which is the opposite to what the comments state.
