### PR TITLE
call forgotten this._super() in DS.LSAdapter.init

### DIFF
--- a/localstorage_adapter.js
+++ b/localstorage_adapter.js
@@ -33,6 +33,7 @@ DS.LSSerializer = DS.JSONSerializer.extend({
 DS.LSAdapter = DS.Adapter.extend(Ember.Evented, {
 
   init: function() {
+    this._super();
     this._loadData();
   },
 


### PR DESCRIPTION
Gives the LSAdapter all the stuff from DS.Adapter, like `registerTransform` actually registering transform functions for custom types.
