### PR TITLE
[#15] Handling 'QUOTA_EXCEEDED_ERR' in Chrome

### DIFF
--- a/localstorage_adapter.js
+++ b/localstorage_adapter.js
@@ -175,7 +175,11 @@ DS.LSAdapter = DS.Adapter.extend(Ember.Evented, {
       records.forEach(function(record) {
         store.recordWasError(record);
       });
+      /* RunnerRick - Not sure if both of these events should be triggered
+          or if some object detection is necessary to decide. */
       this.trigger('QUOTA_EXCEEDED_ERR', records);
+      // Handling the case where Chrome 28 reports the error.name as 'QuotaExceededError'.
+      this.trigger('QuotaExceededError', records);
     }
   },
 
@@ -184,7 +188,9 @@ DS.LSAdapter = DS.Adapter.extend(Ember.Evented, {
       localStorage.setItem(this._getNamespace(), JSON.stringify(this._data));
       return true;
     } catch(error) {
-      if (error.name == 'QUOTA_EXCEEDED_ERR') {
+      // Handling the case where Chrome 28 reports the error.name as 'QuotaExceededError'.
+      var name = error.name.toUpperCase();
+      if (name === 'QUOTA_EXCEEDED_ERR' || name === 'QUOTAEXCEEDEDERROR') {
         return false;
       } else {
         throw new Error(error);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -138,7 +138,9 @@ function occupyLocalStorage() {
     try {
       localStorage.setItem('junk', item);
     } catch(error) {
-      if (error.name === 'QUOTA_EXCEEDED_ERR') {
+      // Handling the case where Chrome 28 reports the error.name as 'QuotaExceededError'.
+      var name = error.name.toUpperCase();
+      if (name === 'QUOTA_EXCEEDED_ERR' || name === 'QUOTAEXCEEDEDERROR') {
         return false;
       }
     }

--- a/test/tests.js
+++ b/test/tests.js
@@ -177,6 +177,7 @@ test('QUOTA_EXCEEDED_ERR when storage is full', function() {
   occupyLocalStorage();
   var handler = sinon.spy();
   adapter.on('QUOTA_EXCEEDED_ERR', handler);
+  adapter.on('QuotaExceededError', handler);
 
   list = List.createRecord({name: n100k});
 


### PR DESCRIPTION
###### Summary of Changes
1. Wherever the code evaluates `error.name === 'QUOTA_EXCEEDED_ERR'`, changed it to also check for `'QuotaExceededError'`.
2. Wherever an event handler is created for `'QUOTA_EXCEEDED_ERR'` it is also created for `'QuotaExceededError'`.
3. Wherever the code triggers a `'QUOTA_EXCEEDED_ERR'` event it also triggers a `'QuotaExceededError'` event. (Not sure if it is harmful for both events to be triggered.)

See also [Issue #15](https://github.com/rpflorence/ember-localstorage-adapter/issues/15).
