### PR TITLE
Fixed an issue with findAll not finding relationships

### DIFF
--- a/localstorage_adapter.js
+++ b/localstorage_adapter.js
@@ -212,6 +212,11 @@
       for (var id in namespace.records) {
         results.push(Ember.copy(namespace.records[id]));
       }
+
+      if (results.get('length')) {
+        results = this.loadRelationshipsForMany(type, results);
+      }
+
       return Ember.RSVP.resolve(results);
     },
 
@@ -371,7 +376,7 @@
 
             embedPromise = new Ember.RSVP.Promise(function(resolve, reject) {
               promise.then(function(relationRecord) {
-                var finalPayload = adapter.addEmbeddedPayload(record, relationName, relationRecord)
+                var finalPayload = adapter.addEmbeddedPayload(record, relationName, relationRecord);
                 resolve(finalPayload);
               });
             });


### PR DESCRIPTION
This issue was causing some weird behavior when trying to fetch a certain record for me, so figured it makes sense to just load the relationships. Maybe we should create a way to opt out of getting the relationships? But then again, I don't really see the use for that, since it doesn't take longer time, and the localstorage can't be all that big anyway.
