### PR TITLE
lets modelNamespace return key.typeKey instead of (subclass of DS.Model)

### DIFF
--- a/localstorage_adapter.js
+++ b/localstorage_adapter.js
@@ -277,7 +277,7 @@
     },
 
     modelNamespace: function(type) {
-      return type.url || type.toString();
+      return type.url || type.typeKey;
     },
 
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,7 +1,7 @@
 Ember.ENV.TESTING = true;
 
 var FIXTURES = {
-  'App.List': {
+  'list': {
     records: {
       'l1': { id: 'l1', name: 'one', b: true, items: ['i1', 'i2'] },
       'l2': { id: 'l2', name: 'two', b: false, items: [] },
@@ -9,14 +9,14 @@ var FIXTURES = {
     }
   },
 
-  'App.Item': {
+  'item': {
     records: {
       'i1': { id: 'i1', name: 'one', list: 'l1' },
       'i2': { id: 'i2', name: 'two', list: 'l1' }
     }
   },
 
-  'App.Order': {
+  'order': {
     records: {
       'o1': { id: 'o1', name: 'one', b: true, hours: ['h1', 'h2'] },
       'o2': { id: 'o2', name: 'two', b: false, hours: [] },
@@ -25,7 +25,7 @@ var FIXTURES = {
     }
   },
 
-  'App.Hour': {
+  'hour': {
     records: {
       'h1': { id: 'h1', name: 'one', amount: 4, order: 'o1' },
       'h2': { id: 'h2', name: 'two', amount: 3, order: 'o1' },

--- a/test/tests.js
+++ b/test/tests.js
@@ -19,14 +19,10 @@ module('DS.LSAdapter', {
       items: DS.hasMany('item')
     });
 
-    App.List.toString = stringify('App.List');
-
     App.Item = DS.Model.extend({
       name: DS.attr('string'),
       list: DS.belongsTo('list')
     });
-
-    App.Item.toString = stringify('App.Item');
 
     App.Order = DS.Model.extend({
       name: DS.attr('string'),
@@ -34,15 +30,11 @@ module('DS.LSAdapter', {
       hours: DS.hasMany('hour')
     });
 
-    App.Order.toString = stringify('App.Order');
-
     App.Hour = DS.Model.extend({
       name: DS.attr('string'),
       amount: DS.attr('number'),
       order: DS.belongsTo('order')
     });
-
-    App.Hour.toString = stringify('App.Hour');
 
     env = setupStore({
       list: App.List,


### PR DESCRIPTION
addresses #47

@kurko I changed the fixtures and removed the toString mocks in the tests.
Please review.
