### PR TITLE
Fixed include of jquery in index.html

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -10,7 +10,7 @@
   <div id="qunit"></div>
 
   <!-- adapter deps -->
-  <script src="../bower_components/jquery/jquery.js"></script>
+  <script src="../bower_components/jquery/dist/jquery.js"></script>
   <script src="../bower_components/handlebars/handlebars.js"></script>
   <script src="../bower_components/ember/ember.js"></script>
   <script src="../bower_components/ember-data/ember-data.js"></script>


### PR DESCRIPTION
The tests have been failing. This fixes the include of jquery in the test/index.html file, since jquery had changed the way boxer installs it.
