### PR TITLE
Honor explicit inverse names with hasMany fields

### DIFF
--- a/localstorage_adapter.js
+++ b/localstorage_adapter.js
@@ -55,7 +55,8 @@
     extractSingle: function(store, type, payload) {
       if (payload && payload._embedded) {
         for (var relation in payload._embedded) {
-          var typeName = Ember.String.singularize(relation),
+          var relType = type.typeForRelationship(relation);
+          var typeName = relType.typeKey,
               embeddedPayload = payload._embedded[relation];
 
           if (embeddedPayload) {


### PR DESCRIPTION
This was causing an exception when loading saved records.

EG:

``` javascript
var Node = DS.Model({
  parent: DS.belongsTo('node', {inverse: 'children'}),
  children: DS.belongsTo('node', {inverse: 'parent'})
});
```

Causes an exception which describes itself as `can not find model "children"` - because it was looking up the type based on a singularized version of the key.
