### PR TITLE
Reject clause whenever the object is not in the LocalStorage

### DIFF
--- a/localstorage_adapter.js
+++ b/localstorage_adapter.js
@@ -124,6 +124,7 @@
         var record = Ember.A(namespace.records[id]);
 
         if (!record || !record.hasOwnProperty('id')) {
+          store.dematerializeRecord(store.typeMapFor(type).idToRecord[id]);
           reject();
           return;
         }

--- a/test/tests.js
+++ b/test/tests.js
@@ -65,9 +65,12 @@ test('find with id', function() {
 });
 
 test('find non-existing record', function () {
+  expect(2);
+
   stop();
   store.find("list", "unknown").catch(function () {
     ok(true);
+    equal(store.hasRecordForId("list", "unknown"), false);
     start();
   });
 });


### PR DESCRIPTION
Here is the original problem :
http://stackoverflow.com/questions/23253021/lsadapter-store-findtype-id-tries-to-push-a-new-record/23642442#23642442

This pull request fix this because it allows us to catch the rejection and create the object properly into the store  if it is not found.
