### PR TITLE
Generate RFC4122 UUIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,27 @@ List.reopen({
 });
 ```
 
+### Ability to generate other UUIDs
+
+This example overrides the generation of ids of the library, and instead
+generates RFC4122 ids (aka PostgreSQL uuids):
+
+```js
+import DS from 'ember-data';
+
+export default DS.LSAdapter.extend({
+  generateIdForRecord: function() {
+    var s4 = function () {
+      return Math.floor((1 + Math.random()) * 0x10000)
+                 .toString(16)
+                 .substring(1);
+    };
+    return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
+           s4() + '-' + s4() + s4() + s4();
+  }
+});
+```
+
 ### Quota Exceeded Handler
 
 Browser's `localStorage` has limited space, if you try to commit application data and the browser is out of space, then the adapter will trigger the `QUOTA_EXCEEDED_ERR` event.

--- a/localstorage_adapter.js
+++ b/localstorage_adapter.js
@@ -247,13 +247,7 @@
     },
 
     generateIdForRecord: function () {
-      var s4 = function () {
-        return Math.floor((1 + Math.random()) * 0x10000)
-                   .toString(16)
-                   .substring(1);
-      }
-      return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
-             s4() + '-' + s4() + s4() + s4();
+      return Math.random().toString(32).slice(2).substr(0, 5);
     },
 
     // private


### PR DESCRIPTION
It's the standard PostgreSQL follows.

This allows client and server side id generation, with trivial syncing. This
format is also used in Backbone.dualStorage:
https://github.com/nilbus/Backbone.dualStorage/blob/master/backbone.dualstorage.js#L82-L96

Sending ids to a Postgres API raised before this commit:

```
ERROR:  invalid input syntax for uuid: "ducg0"
```

Related links:
- http://www.ietf.org/rfc/rfc4122.txt
- http://www.postgresql.org/docs/8.3/static/datatype-uuid.html
- http://stackoverflow.com/a/105074/356060
