### PR TITLE
Allow installation of Local Storage Adapter as an Ember CLI addon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 tmp-update
 bower_components
+node_modules
+ember-localstorage-adapter

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ App.ApplicationAdapter = DS.LSAdapter.extend({
 });
 ```
 
+If you are using Ember Localstorage Adapter within an Ember CLI project you can install it as an addon with the following command:
+
+```sh
+npm install --save-dev ember-localstorage-adapter
+```
+
 ### Local Storage Namespace
 
 All of your application data lives on a single `localStorage` key, it defaults to `DS.LSAdapter` but if you supply a `namespace` option it will store it there:

--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var path = require('path');
+var fs = require('fs');
+
+module.exports = {
+  name: 'Ember Localstorage Adapter',
+  treeFor: function(name) {
+    if (name !== 'vendor') { return; }
+
+    var treePath =  path.join(__dirname, '..', 'ember-localstorage-adapter');
+
+    var namespacedPath = path.join(treePath, 'ember-localstorage-adapter');
+
+    if(!fs.existsSync(namespacedPath)) {
+      fs.mkdirSync(namespacedPath);
+    }
+
+    fs.writeFileSync(
+      path.join(namespacedPath, 'localstorage_adapter.js'),
+      fs.readFileSync(path.join(treePath, 'localstorage_adapter.js'), {encoding: 'utf8'})
+    );
+
+    return unwatchedTree(treePath);
+  },
+  included: function(app){
+    this.app = app;
+    this.app.import('vendor/ember-localstorage-adapter/localstorage_adapter.js');
+  }
+};
+
+function unwatchedTree(dir) {
+  return {
+    read:    function() { return dir; },
+    cleanup: function() { }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "ember-localstorage-adapter",
+  "version": "0.3.2",
+  "description": "Store your ember application data in localStorage.",
+  "main": "localstorage_adapter.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "phantomjs test/runner.js test/index.html"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kurko/ember-localstorage-adapter"
+  },
+  "keywords": [
+    "ember-addon"
+  ],
+  "ember-addon": {
+    "main": "ember-addon-main.js",
+    "after": "ember-cli-ember-data"
+  },
+  "author": "Ryan Florence <rpflorence@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/kurko/ember-localstorage-adapter/issues"
+  },
+  "homepage": "https://github.com/kurko/ember-localstorage-adapter"
+}


### PR DESCRIPTION
Should just need to run `npm publish` in order to make it available via the instructions in the `README`.  
