### PR TITLE
Load after ember-data, not ember-cli-ember-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "ember-addon": {
     "main": "ember-addon-main.js",
-    "after": "ember-cli-ember-data"
+    "after": "ember-data"
   },
   "author": "Ryan Florence <rpflorence@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
[ember-cli-ember-data](https://github.com/twokul/ember-cli-ember-data) is deprecated and no longer included in Ember-CLI.

Fixes #82.
