### PR TITLE
Update to use ember-data instead of ember-data wrapper addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "ember-addon": {
     "main": "ember-addon-main.js",
-    "after": "ember-cli-ember-data"
+    "after": "ember-data"
   },
   "author": "Ryan Florence <rpflorence@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Fixes the following error when including LSA as an addon:

![](http://i.imgur.com/oR68kFX.png)

More information on this error can be found in the link in the comment (issue number)
