### PR TITLE
Remove reference to DS.RelationshipChange

### DIFF
--- a/localstorage_adapter.js
+++ b/localstorage_adapter.js
@@ -8,7 +8,7 @@
     serializeHasMany: function(record, json, relationship) {
       var key = relationship.key;
       var payloadKey = this.keyForRelationship ? this.keyForRelationship(key, "hasMany") : key;
-      var relationshipType = DS.RelationshipChange.determineRelationshipType(record.constructor, relationship);
+      var relationshipType = record.constructor.determineRelationshipType(record.constructor, relationship);
 
       if (relationshipType === 'manyToNone' ||
           relationshipType === 'manyToMany' ||


### PR DESCRIPTION
From ember-data 1.0.0-beta.8 to 1.0.0-beta.11, it seems that DS.RelationshipChange has been removed, and this is the new approach in ember-data.

Perhaps as part of this PR the dependencies of this project should be updated to require ember-data 1.0.0-beta.11?
