### PR TITLE
Cannot read property 'modelFor' of undefined

### DIFF
--- a/localstorage_adapter.js
+++ b/localstorage_adapter.js
@@ -8,7 +8,7 @@
     serializeHasMany: function(snapshot, json, relationship) {
       var key = relationship.key;
       var payloadKey = this.keyForRelationship ? this.keyForRelationship(key, "hasMany") : key;
-      var relationshipType = snapshot.type.determineRelationshipType(relationship);
+      var relationshipType = snapshot.type.determineRelationshipType(relationship, this.store);
 
       if (relationshipType === 'manyToNone' ||
           relationshipType === 'manyToMany' ||


### PR DESCRIPTION
Posibly related to #121? But I'm on ember-data 1.13.4, just need to pass store to `determineRelationshipType`.