### PR TITLE
Removes all deprecations and conforms to ember the last ember 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Status](https://travis-ci.org/kurko/ember-localstorage-adapter.svg?branch=master
 
 Store your ember application data in localStorage.
 
-Compatible with Ember Data 1.0.beta.16
+Compatible with Ember Data 1.13
 
 **NOTE**: New versions of the `localStorage` adapter are no longer compatible
 with older versions of Ember Data. For older versions, checkout the `pre-beta`

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "vendor"
   ],
   "dependencies": {
-    "ember-data": "1.13.5",
-    "ember": ">= 1.12.0"
+    "ember-data": "1.13.11",
+    "ember": "1.13.9"
   }
 }

--- a/localstorage_adapter.js
+++ b/localstorage_adapter.js
@@ -4,7 +4,7 @@
   'use strict';
 
   DS.LSSerializer = DS.JSONSerializer.extend({
-	  
+
 	 /**
      * Invokes the new serializer API.
      * This should be removed in 2.0
@@ -23,7 +23,7 @@
         // TODO support for polymorphic manyToNone and manyToMany relationships
       }
     },
-	
+
 	/**
      * Extracts whatever was returned from the adapter.
      *
@@ -84,7 +84,7 @@
       }
       return normalPayload;
     },
-	
+
 	/**
      * This is exactly the same as extractSingle, but used in an array.
      *
@@ -116,6 +116,26 @@
   });
 
   DS.LSAdapter = DS.Adapter.extend(Ember.Evented, {
+
+    /**
+    * This governs if promises will be resolved immeadiatly for `findAll`
+    * requests or if they will wait for the store requests to finish. This matches
+    * the ember < 2.0 behavior.
+    * [deprecation id: ds.adapter.should-reload-all-default-behavior]
+    */
+    shouldReloadAll: function(modelClass, snapshotArray){
+      return true;
+    },
+
+    /**
+     * Conforms to ember <2.0 behavior, in order to remove deprecation.
+     * Probably safe to remove if running on ember 2.0
+     * [deprecation id: ds.model.relationship-changing-to-asynchrounous-by-default]
+     */
+    shouldBackgroundReloadRecord: function(){
+      return false;
+    },
+
     /**
       This is the main entry point into finding records. The first parameter to
       this method is the model's name as a string.

--- a/test/tests.js
+++ b/test/tests.js
@@ -16,24 +16,24 @@ module('DS.LSAdapter', {
     App.List = DS.Model.extend({
       name: DS.attr('string'),
       b: DS.attr('boolean'),
-      items: DS.hasMany('item')
+      items: DS.hasMany('item', {async: true})
     });
 
     App.Item = DS.Model.extend({
       name: DS.attr('string'),
-      list: DS.belongsTo('list')
+      list: DS.belongsTo('list', {async: true})
     });
 
     App.Order = DS.Model.extend({
       name: DS.attr('string'),
       b: DS.attr('boolean'),
-      hours: DS.hasMany('hour')
+      hours: DS.hasMany('hour', {async: true})
     });
 
     App.Hour = DS.Model.extend({
       name: DS.attr('string'),
       amount: DS.attr('number'),
-      order: DS.belongsTo('order')
+      order: DS.belongsTo('order', {async: true})
     });
 
     App.Person = DS.Model.extend({
@@ -421,7 +421,7 @@ test("extractArray calls extractSingle", function() {
 
   store.findRecord('list').then(function(lists) {
     equal(callback.callCount, 3);
-    
+
     start();
   });
 
@@ -433,7 +433,7 @@ test('date is loaded correctly', function() {
   stop();
 
   var date = new Date(1988, 11, 28);
-  
+
   var person = store.createRecord('person', { name: 'Tom', birthdate: date });
   person.save().then(function() {
     store.query('person', { name: 'Tom' }).then(function(records) {
@@ -496,4 +496,3 @@ test('handles localStorage being unavailable', function() {
 //   // clean up
 //   localStorage.removeItem('junk');
 // });
-


### PR DESCRIPTION
This does not repair tests. In order for tests to pass https://github.com/kurko/ember-localstorage-adapter/pull/130 has to be pulled in. But i tested the merge and the tests pass afterwards. 