### PR TITLE
On query, resolve an empty result instead of throwing error

### DIFF
--- a/addon/adapters/ls-adapter.js
+++ b/addon/adapters/ls-adapter.js
@@ -112,7 +112,7 @@ const LSAdapter = DS.Adapter.extend(Ember.Evented, {
     if (results.get('length')) {
       return this.loadRelationshipsForMany(store, type, results);
     } else {
-      return Ember.RSVP.reject();
+      return Ember.RSVP.resolve(results);
     }
   },
 

--- a/tests/integration/adapters/ls-adapter-test.js
+++ b/tests/integration/adapters/ls-adapter-test.js
@@ -101,11 +101,11 @@ test('query', function(assert) {
   });
 });
 
-test('query rejects promise when there are no records', function(assert) {
+test('query resolves empty when there are no records', function(assert) {
   const done = assert.async();
   assert.expect(2);
-  run(store, 'query', 'list', {name: /unknown/}).catch(() => {
-    assert.ok(true);
+  run(store, 'query', 'list', {name: /unknown/}).then(list => {
+    assert.ok(Ember.isEmpty(list));
     assert.equal(store.hasRecordForId('list', 'unknown'), false);
     done();
   });
@@ -205,8 +205,8 @@ test('deleteRecord', function(assert) {
   const done = assert.async();
 
   const assertListIsDeleted = () => {
-    return store.query('list', {name: 'one'}).catch(() => {
-      assert.ok(true, 'List was deleted');
+    return store.query('list', {name: 'one'}).then(list => {
+      assert.ok(Ember.isEmpty(list), 'List was deleted');
       done();
     });
   };


### PR DESCRIPTION
Fixes #185 

When using Sentry this localstorage adapter reports a promise error every time a query result is empty. How about resolving no results instead of rejecting the promise?