### PR TITLE
Use `includes` instead of `contains` if possible

### DIFF
--- a/addon/serializers/ls-serializer.js
+++ b/addon/serializers/ls-serializer.js
@@ -99,7 +99,7 @@ export default DS.JSONSerializer.extend({
 
       if(normalized.included){
         normalized.included.forEach(function(included){
-          if(!response.included.contains(included.id)){
+          if(!response.included.includes(included.id)){
             response.included.addObject(included);
           }
         });

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^5.1.6",
+    "ember-runtime-enumerable-includes-polyfill": "^1.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
I believe this prevents an ember-data 2.x deprecation warning while staying compatible with the ember-data 1.x API.